### PR TITLE
21 allow to skip the quick tests on specific branches

### DIFF
--- a/.github/workflows/CRAN_checks.yml
+++ b/.github/workflows/CRAN_checks.yml
@@ -20,6 +20,7 @@ permissions:
 jobs:
   R-CMD-check:
     runs-on: ubuntu-22.04
+    if: ${{ !startsWith(github.event.head_commit.message, 'noT') }}  # skip on commits starting with 'noT'
     container:
       image: ${{ matrix.image-source }}/${{ matrix.os }}/${{ matrix.compiler }}/${{ matrix.r-version }}/abn:${{ vars.CONTAINER_VERSION || 'latest' }}
       credentials:

--- a/.github/workflows/quick-testthat.yml
+++ b/.github/workflows/quick-testthat.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   build-install-test:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.head_commit.message, 'noT') }}
+    if: ${{ github.event_name != 'pull_request' && !startsWith(github.event.head_commit.message, 'noT') }}
     runs-on: ubuntu-22.04
     name: Testing ${{ matrix.os }} (${{ matrix.compiler}}-${{ matrix.r-version }})
     # runs-on: ubuntu-latest

--- a/.github/workflows/quick-testthat.yml
+++ b/.github/workflows/quick-testthat.yml
@@ -9,6 +9,7 @@ on:
       - "**"           # include all branches
       - "!main"        # then exclude only
       - "!master"      # those two
+      - "!**noT**"     # exclude all branches containing noT in their name
   pull_request:
     branches-ignore:   # do not run on pull
       - main           # requests on default
@@ -23,7 +24,7 @@ permissions:
 
 jobs:
   build-install-test:
-    if: github.event_name != 'pull_request'
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.head_commit.message, 'WIP') }}
     runs-on: ubuntu-22.04
     name: Testing ${{ matrix.os }} (${{ matrix.compiler}}-${{ matrix.r-version }})
     # runs-on: ubuntu-latest

--- a/.github/workflows/quick-testthat.yml
+++ b/.github/workflows/quick-testthat.yml
@@ -24,7 +24,7 @@ permissions:
 
 jobs:
   build-install-test:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.head_commit.message, 'WIP') }}
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.head_commit.message, 'noT') }}
     runs-on: ubuntu-22.04
     name: Testing ${{ matrix.os }} (${{ matrix.compiler}}-${{ matrix.r-version }})
     # runs-on: ubuntu-latest


### PR DESCRIPTION
quick tests are skipped on branches that contain the string `noT` in their name and on every commit that starts with the string `noT`.

_Note:_ When a merge request is marked as ready-for-review, then CRAN-like tests are triggered. This action has no such condition implemented so far, so it will run independent on `noT` in the branch name or current commit.

@matteodelucchi should we also allow to skip the CRAN like tests if a commit message starts with `noT`?