### PR TITLE
start to publish releases

### DIFF
--- a/.github/workflows/CRAN_checks.yml
+++ b/.github/workflows/CRAN_checks.yml
@@ -7,10 +7,9 @@ on:
   push:
     branches: 
       - main
-      - 8-package-archive-as-artifact  # TODO: remove! just for dev
     tags:
-      - v[0-9]+.[0-9]+.[0-9]+
-      - [0-9]+.[0-9]+.[0-9]+
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+"
       - '[0-9]+.[0-9]+.[0-9]+-alpha.1'  # TODO: remove! just for dev
   pull_request:
     types: [ ready_for_review ]

--- a/.github/workflows/CRAN_checks.yml
+++ b/.github/workflows/CRAN_checks.yml
@@ -10,7 +10,6 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+"
-      - '[0-9]+.[0-9]+.[0-9]+-alpha.1'  # TODO: remove! just for dev
   pull_request:
     types: [ ready_for_review ]
     branches: [ main, master ]

--- a/.github/workflows/CRAN_checks.yml
+++ b/.github/workflows/CRAN_checks.yml
@@ -6,6 +6,10 @@ name: CRAN-like checks
 on:
   push:
     branches: [ main, master, 8-package-archive-as-artifact] # for temporary testing
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - [0-9]+.[0-9]+.[0-9]+
+      - [0-9]+.[0-9]+.[0-9]+-alpha.1  # TODO: remove! just for dev
   pull_request:
     types: [ ready_for_review ]
     branches: [ main, master ]

--- a/.github/workflows/CRAN_checks.yml
+++ b/.github/workflows/CRAN_checks.yml
@@ -5,7 +5,7 @@ name: CRAN-like checks
 
 on:
   push:
-    branches: [ main, master] # for temporary testing
+    branches: [ main, master, 8-package-archive-as-artifact] # for temporary testing
   pull_request:
     types: [ ready_for_review ]
     branches: [ main, master ]

--- a/.github/workflows/CRAN_checks.yml
+++ b/.github/workflows/CRAN_checks.yml
@@ -5,11 +5,13 @@ name: CRAN-like checks
 
 on:
   push:
-    branches: [ main, master, 8-package-archive-as-artifact] # for temporary testing
+    branches: 
+      - main
+      - 8-package-archive-as-artifact  # TODO: remove! just for dev
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
       - [0-9]+.[0-9]+.[0-9]+
-      - [0-9]+.[0-9]+.[0-9]+-alpha.1  # TODO: remove! just for dev
+      - '[0-9]+.[0-9]+.[0-9]+-alpha.1'  # TODO: remove! just for dev
   pull_request:
     types: [ ready_for_review ]
     branches: [ main, master ]

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -3,7 +3,7 @@ name: Publish Release
 # Only trigger, when CRAN-like checks succeed 
 on:
   workflow_run:
-    branches: [main, 8-package-archive-as-artifact]
+    branches: [main]
     workflows: ["CRAN-like checks"]
     types:
       - completed

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,46 @@
+name: Publish Release
+
+# Only trigger, when CRAN-like checks succeed 
+on:
+  workflow_run:
+    branches: [main, 8-package-archive-as-artifact]
+    workflows: ["CRAN-like checks"]
+    types:
+      - completed
+
+env:
+  BUILD_LOC: "./build"
+
+jobs:
+   publish:
+     runs_on: ubuntu-22.04
+     if: ${{ github.ref_type == 'tag' && github.event.workflow_run.conclusion == 'success' }}
+     permissions:
+       contents: write
+     steps:
+      - uses: actions/checkout@v4
+      - name: Create build location
+        run: |
+            mkdir ${{ env.BUILD_LOC }}
+        shell: bash
+      - name: Disable renv
+        run: |
+            renv::deactivate()
+        shell: Rscript {0}
+      - name: Change permissions of configure
+        run: |
+            chmod +x configure
+        shell: bash
+      - name: Install package dependencies
+        run: |
+            devtools::install_deps(pkg = '.', dependencies = TRUE, upgrade='never')
+        shell: Rscript {0}
+      - name: Build the package
+        run: |
+            devtools::build(pkg = '.', path = '${{ env.BUILD_LOC }}/abn.tar.gz')
+        shell: Rscript {0}
+      - uses: ncipollo/release-action@v1
+        with:
+          artifacts: "${{ env.BUILD_LOC }}/abn.tar.gz"
+          # TODO: decide if we want to have some optional description:
+          # bodyFile: "body.md"

--- a/.github/workflows/quick-testthat.yml
+++ b/.github/workflows/quick-testthat.yml
@@ -10,7 +10,6 @@ on:
       - "!main"        # then exclude only
       - "!master"      # those two
       - "!**noT**"     # exclude all branches containing noT in their name
-      - "!8-package-archive-as-artifact"  # TODO: remove! just for dev
   pull_request:
     branches-ignore:   # do not run on pull
       - main           # requests on default

--- a/.github/workflows/quick-testthat.yml
+++ b/.github/workflows/quick-testthat.yml
@@ -10,6 +10,7 @@ on:
       - "!main"        # then exclude only
       - "!master"      # those two
       - "!**noT**"     # exclude all branches containing noT in their name
+      - "!8-package-archive-as-artifact"  # TODO: remove! just for dev
   pull_request:
     branches-ignore:   # do not run on pull
       - main           # requests on default


### PR DESCRIPTION
This adds an additional workflow that is triggered on a successful run of the `CRAN-like checks` and only if `github.ref_type == 'tag', i.e. when a new tag is pushed.

It builds the package (just like the `Quick build and test` actions does and publishes a new release containing the resulting *.tar.gz.