### PR TITLE
memory-check in "slow" release cycle

### DIFF
--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -45,21 +45,21 @@ jobs:
         run: |
             devtools::install_deps(pkg = '.', dependencies = TRUE, upgrade='never')
         shell: Rscript {0}
-    - name: Configuration for valgrind (and ASan)
-      run: |
-        echo "PKG_CFLAGS = -g -fsanitize=address -fno-omit-frame-pointer" >> src/Makevars
-        echo "PKG_CXXFLAGS = -g -fsanitize=address -fno-omit-frame-pointer" >> src/Makevars
-      shell: bash
-    - name: Install package
-      run: |
-        devtools::install(upgrade='never')
-      shell: Rscript {0}
-    - name: valgrind - memcheck test single file
-      run: |
-        R -d "valgrind --tool=memcheck \
-        --leak-check=full \
-        --errors-for-leak-kinds=definite \
-        --error-exitcode=1" \
-        --vanilla \
-        -e "devtools::test_file('./tests/testthat/test-fitabn.R')"
-      shell: bash
+      - name: Configuration for valgrind (and ASan)
+        run: |
+          echo "PKG_CFLAGS = -g -fsanitize=address -fno-omit-frame-pointer" >> src/Makevars
+          echo "PKG_CXXFLAGS = -g -fsanitize=address -fno-omit-frame-pointer" >> src/Makevars
+        shell: bash
+      - name: Install package
+        run: |
+          devtools::install(upgrade='never')
+        shell: Rscript {0}
+      - name: valgrind - memcheck test single file
+        run: |
+          R -d "valgrind --tool=memcheck \
+          --leak-check=full \
+          --errors-for-leak-kinds=definite \
+          --error-exitcode=1" \
+          --vanilla \
+          -e "devtools::test_file('./tests/testthat/test-fitabn.R')"
+        shell: bash

--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -49,5 +49,5 @@ jobs:
             if (Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "") == "") Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
             if (Sys.getenv("_R_CHECK_CRAN_INCOMING_", "") == "") Sys.setenv("_R_CHECK_CRAN_INCOMING_" = "false")
             cat("check-dir-path=", file.path(getwd(), ("check")), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
-            check_results <- rcmdcheck::rcmdcheck(".", args = (c("--no-manual", "--use-gct", "--use-valgrind")), build_args = ("--no-manual"), error_on = ("error"), check_dir = ("check"))
+            check_results <- rcmdcheck::rcmdcheck(".", args = (c("--no-manual", "--use-gct"), build_args = ("--no-manual"), error_on = ("error"), check_dir = ("check"))
         shell: Rscript {0}

--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -49,5 +49,5 @@ jobs:
             if (Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "") == "") Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
             if (Sys.getenv("_R_CHECK_CRAN_INCOMING_", "") == "") Sys.setenv("_R_CHECK_CRAN_INCOMING_" = "false")
             cat("check-dir-path=", file.path(getwd(), ("check")), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
-            check_results <- rcmdcheck::rcmdcheck(".", args = (c("--no-manual", "--use-gct"), build_args = ("--no-manual"), error_on = ("error"), check_dir = ("check"))
+            check_results <- rcmdcheck::rcmdcheck(".", args = (c("--no-manual", "--use-gct")), build_args = ("--no-manual"), error_on = ("error"), check_dir = ("check"))
         shell: Rscript {0}

--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: Installing valgrind
         run: |
-          sudo apt-get install valgrind
+          apt-get install valgrind -y
         shell: bash
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -1,0 +1,52 @@
+# Defines the check and tests to run when in a release cycle
+name: Release Cycle Checks
+
+
+on:
+  push:
+    branch:
+      - "release-[0-9]+.[0-9]+.[0-9]+"
+      # TODO: remove next line
+      - "26-tests-tracking-memory-usage-the-slow-pipeline"
+
+jobs:
+  checks-with-gctorture:
+    runs-on: ubuntu-22.04
+    name: Running R CMD check with gctorture enabled
+    strategy:
+      fail-fast: false
+      matrix:
+        r-version: ['devel']  # ['3.6.3', '4.1.1']
+        os: ['debian']
+        compiler: ['gcc', 'clang']
+    container:
+      image: ${{ vars.CONTAINER_SOURCE }}/${{ vars.CONTAINER_RELEASE || 'debian/gcc/release' }}/abn:${{ vars.CONTAINER_VERSION || 'latest' }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Disable renv
+        run: |
+            renv::deactivate()
+        shell: Rscript {0}
+      - name: Change permissions of configure
+        run: |
+            chmod +x configure
+        shell: bash
+      - name: Install package dependencies
+        run: |
+            devtools::install_deps(pkg = '.', dependencies = TRUE, upgrade='never')
+        shell: Rscript {0}
+      - name: R CMD check with memory checks
+        run: |
+            options(crayon.enabled = TRUE)
+            cat("LOGNAME=", Sys.info()[["user"]], "\n", sep = "", file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+            Sys.setenv("VALGRIND_OPTS", "--memcheck:leak-check=yes --memcheck:track-origins=yes")
+            if (Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "") == "") Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
+            if (Sys.getenv("_R_CHECK_CRAN_INCOMING_", "") == "") Sys.setenv("_R_CHECK_CRAN_INCOMING_" = "false")
+            cat("check-dir-path=", file.path(getwd(), ("check")), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
+            check_results <- rcmdcheck::rcmdcheck(".", args = (c("--no-manual", "--use-gct", "--use-valgrind")), build_args = ("--no-manual"), error_on = ("error"), check_dir = ("check"))

--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -26,6 +26,10 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
+      - name: Installing valgrind
+        run: |
+          sudo apt-get install valgrind
+        shell: bash
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
@@ -41,13 +45,21 @@ jobs:
         run: |
             devtools::install_deps(pkg = '.', dependencies = TRUE, upgrade='never')
         shell: Rscript {0}
-      - name: R CMD check with memory checks
-        run: |
-            options(crayon.enabled = TRUE)
-            cat("LOGNAME=", Sys.info()[["user"]], "\n", sep = "", file = Sys.getenv("GITHUB_ENV"), append = TRUE)
-            Sys.setenv("VALGRIND_OPTS" = "--memcheck:leak-check=yes --memcheck:track-origins=yes")
-            if (Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "") == "") Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
-            if (Sys.getenv("_R_CHECK_CRAN_INCOMING_", "") == "") Sys.setenv("_R_CHECK_CRAN_INCOMING_" = "false")
-            cat("check-dir-path=", file.path(getwd(), ("check")), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
-            check_results <- rcmdcheck::rcmdcheck(".", args = (c("--no-manual", "--use-gct")), build_args = ("--no-manual"), error_on = ("error"), check_dir = ("check"))
-        shell: Rscript {0}
+    - name: Configuration for valgrind (and ASan)
+      run: |
+        echo "PKG_CFLAGS = -g -fsanitize=address -fno-omit-frame-pointer" >> src/Makevars
+        echo "PKG_CXXFLAGS = -g -fsanitize=address -fno-omit-frame-pointer" >> src/Makevars
+      shell: bash
+    - name: Install package
+      run: |
+        devtools::install(upgrade='never')
+      shell: Rscript {0}
+    - name: valgrind - memcheck test single file
+      run: |
+        R -d "valgrind --tool=memcheck \
+        --leak-check=full \
+        --errors-for-leak-kinds=definite \
+        --error-exitcode=1" \
+        --vanilla \
+        -e "devtools::test_file('./tests/testthat/test-fitabn.R')"
+      shell: bash

--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
             options(crayon.enabled = TRUE)
             cat("LOGNAME=", Sys.info()[["user"]], "\n", sep = "", file = Sys.getenv("GITHUB_ENV"), append = TRUE)
-            Sys.setenv("VALGRIND_OPTS", "--memcheck:leak-check=yes --memcheck:track-origins=yes")
+            Sys.setenv("VALGRIND_OPTS" = "--memcheck:leak-check=yes --memcheck:track-origins=yes")
             if (Sys.getenv("_R_CHECK_FORCE_SUGGESTS_", "") == "") Sys.setenv("_R_CHECK_FORCE_SUGGESTS_" = "false")
             if (Sys.getenv("_R_CHECK_CRAN_INCOMING_", "") == "") Sys.setenv("_R_CHECK_CRAN_INCOMING_" = "false")
             cat("check-dir-path=", file.path(getwd(), ("check")), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)

--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -50,3 +50,4 @@ jobs:
             if (Sys.getenv("_R_CHECK_CRAN_INCOMING_", "") == "") Sys.setenv("_R_CHECK_CRAN_INCOMING_" = "false")
             cat("check-dir-path=", file.path(getwd(), ("check")), "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
             check_results <- rcmdcheck::rcmdcheck(".", args = (c("--no-manual", "--use-gct", "--use-valgrind")), build_args = ("--no-manual"), error_on = ("error"), check_dir = ("check"))
+        shell: Rscript {0}

--- a/.github/workflows/release_checks.yml
+++ b/.github/workflows/release_checks.yml
@@ -5,9 +5,9 @@ name: Release Cycle Checks
 on:
   push:
     branch:
+      # TODO: only run on creation of release and when a
+      # label is added
       - "release-[0-9]+.[0-9]+.[0-9]+"
-      # TODO: remove next line
-      - "26-tests-tracking-memory-usage-the-slow-pipeline"
 
 jobs:
   checks-with-gctorture:


### PR DESCRIPTION
Closes #26 


## Decision

Since the memory tracking check will most likely exceed the 6h threshold, we cannot simply rely on the free GH runners and need to establish another option.
For the time being we will simply implement an placeholder job that we can correctly integrate into #81 and set up a more complete memory checking workflow, including also https://github.com/furrer-lab/r-containers/issues/29, afterwards.