### PR TITLE
109 setup sensible code coverage report

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,6 +9,8 @@ Makefile
 \.chglog
 ^CONTRIBUTING\.md$
 \.lintr
+^\.Rbuildignore$
+^\.codecov\.yml$
 
 ^_pkgdown\.yml$
 ^docs$

--- a/.github/workflows/onlabel_CRAN_checks.yml
+++ b/.github/workflows/onlabel_CRAN_checks.yml
@@ -224,7 +224,7 @@ jobs:
           covr::codecov(
             quiet = FALSE,
             clean = FALSE,
-            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package"),
             token = Sys.getenv("CODECOV_TOKEN")
           )
         shell: Rscript {0}

--- a/.github/workflows/onlabel_CRAN_checks.yml
+++ b/.github/workflows/onlabel_CRAN_checks.yml
@@ -205,6 +205,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -224,6 +225,7 @@ jobs:
             quiet = FALSE,
             clean = FALSE,
             install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+            token = Sys.getenv("CODECOV_TOKEN")
           )
         shell: Rscript {0}
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <!-- badges: start -->
 [![status](https://joss.theoj.org/papers/1bbc43a2be86f5d3f831cedb5cf81812/status.svg)](https://joss.theoj.org/papers/1bbc43a2be86f5d3f831cedb5cf81812)
 [![On Label CRAN Checks](https://github.com/furrer-lab/abn/actions/workflows/onlabel_CRAN_checks.yml/badge.svg)](https://github.com/furrer-lab/abn/actions/workflows/onlabel_CRAN_checks.yml)
-![Codecov](https://img.shields.io/codecov/c/github/furrer-lab/abn)
+[![Codecov](https://img.shields.io/codecov/c/github/furrer-lab/abn)](https://app.codecov.io/gh/furrer-lab/abn)
 [![GitHub R package version](https://img.shields.io/github/r-package/v/furrer-lab/abn)](https://github.com/furrer-lab/abn/tags)
 ![cran](https://www.r-pkg.org/badges/version-ago/abn) 
 ![downloads](https://cranlogs.r-pkg.org/badges/grand-total/abn) 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+comment:                  # this is a top-level key
+  layout: " diff, flags, files"
+  behavior: default
+  require_changes: false  # if true: only post the comment if coverage changes
+  require_base: false        # [true :: must have a base report to post]
+  require_head: true       # [true :: must have a head report to post]
+  hide_project_coverage: false # [true :: only show coverage on the git diff]
+  


### PR DESCRIPTION
configured codecov.io report and include it in PR when CRAN-like checks are run.