### PR TITLE
Fix for JAGS 5.0.0: extend simulation length for one test

### DIFF
--- a/tests/testthat/test-simulateabn.R
+++ b/tests/testthat/test-simulateabn.R
@@ -784,6 +784,7 @@ test_that("simulateAbn() simulation works with method 'mle'", {
                                      run.simulation = TRUE,
                                      bugsfile = NULL,
                                      verbose = FALSE,
+                                     n.iter = 50000L,
                                      debug = FALSE)
           })
         },


### PR DESCRIPTION
In preparation for the release of JAGS 5.0.0 I am testing the reverse dependencies of the rjags package on CRAN to ensure they work with the new version.

One of the tests in the abn package fails with JAGS 5.0.0. My diagnosis is that the Monte Carlo error is too large for the given tolerance. I suggest extending the length of the Markov Chain. If the default number of iterations with 10000 with a thinning interval of 100 then this leaves only 100 posterior samples. My suggestion is to increase the number of iterations to 50000 giving 500 posterior samples. This seems to do the trick.