### PR TITLE
Solid expect clauses

### DIFF
--- a/.github/workflows/Macos_setup.yml
+++ b/.github/workflows/Macos_setup.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - "main"
+      - "solid-expect-clauses"
 
 env:
   BUILD_LOC: "./build"

--- a/.github/workflows/Windows_setup.yml
+++ b/.github/workflows/Windows_setup.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches:
       - "main"
-      - "187-issue-with-ragg-within-the-installation-workflow-for-windows"
+      - "solid-expect-clauses"
 env:
   BUILD_LOC: "./build"
   BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -96,7 +96,6 @@ jobs:
 
       - name: run the tests
         run: |
-            pak::pak('r-lib/testthat')
             library("abn")
             testthat::test_local(path='tests', load_package='none')
         shell: Rscript {0}

--- a/.github/workflows/Windows_setup.yml
+++ b/.github/workflows/Windows_setup.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches:
       - "main"
-      - "solid-expect-clauses"
 env:
   BUILD_LOC: "./build"
   BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/tests/testthat/test-build_score_cache_bayes.R
+++ b/tests/testthat/test-build_score_cache_bayes.R
@@ -23,10 +23,9 @@ test_that("General behaviour of buildScoreCache.bayes()", {
   expect_equal(buildScoreCache(data.df=df, data.dists=dist, method = "bayes", max.parents=3, which.nodes=1:5),
                buildScoreCache(data.df=df, data.dists=dist, method = "bayes", max.parents=list(Ozone=3, Solar.R=3, Wind=3, Temp=3, Month=3), which.node=1:5))
   expect_no_error(buildScoreCache(data.df=df, data.dists=dist, method = "bayes", max.parents=list(Ozone=2, Solar.R=4, Wind=4, Temp=4, Month=4), which.node=1:5))
-  expect_error(
+  expect_failure(
     expect_equal(buildScoreCache(data.df=df, data.dists=dist, method = "bayes", max.parents=4, which.node=1:5),
-                 buildScoreCache(data.df=df, data.dists=dist, method = "bayes", max.parents=list(Ozone=2, Solar.R=4, Wind=4, Temp=4, Month=4), which.node=1:5)),
-    regexp = "not equal")
+                 buildScoreCache(data.df=df, data.dists=dist, method = "bayes", max.parents=list(Ozone=2, Solar.R=4, Wind=4, Temp=4, Month=4), which.node=1:5)))
 })
 
 test_that("buildScoreCache.bayes() with Gaussian nodes", {

--- a/tests/testthat/test-tographviz.R
+++ b/tests/testthat/test-tographviz.R
@@ -159,34 +159,37 @@ test_that("toGraphviz() works with all distributions.", {
   })
 
   # check if works with a specific outfile
-  outfile <- tempfile(fileext = ".dot")
+  # The three input forms (abnFit, matrix, abnLearned) are expected to produce
+  # identical dot output for the same underlying DAG. We snapshot the abnFit
+  # variant once and assert the other two match it byte-for-byte.
+  outfile_abnFit <- tempfile(fileext = ".dot")
   # ...with dag as "abnFit"
   expect_no_error({
     toGraphviz(dag=myres.mle,
                # data.df=df,
                # data.dists=mydists,
                # group.var = "Pedigree",
-               outfile=outfile)
+               outfile=outfile_abnFit)
   })
-  expect_snapshot_file(outfile, "graph.dot")
+  expect_snapshot_file(outfile_abnFit, "graph.dot")
   # ...with dag as matrix
-  outfile <- tempfile(fileext = ".dot")
+  outfile_matrix <- tempfile(fileext = ".dot")
   expect_no_error({
     toGraphviz(dag=myres.mle$abnDag$dag,
                data.df=df,
                data.dists=myres.mle$abnDag$data.dists,
                group.var = myres.mle$group.var,
-               outfile=outfile)
+               outfile=outfile_matrix)
   })
-  expect_snapshot_file(outfile, "graph.dot")
+  expect_equal(readLines(outfile_matrix), readLines(outfile_abnFit))
   # ...with dag as "abnLearned"
-  outfile <- tempfile(fileext = ".dot")
+  outfile_abnLearned <- tempfile(fileext = ".dot")
   expect_no_error({
     toGraphviz(dag=mp.dag.mle,
                data.df=df,
                data.dists=mydists,
                group.var = "Pedigree",
-               outfile=outfile)
+               outfile=outfile_abnLearned)
   })
-  expect_snapshot_file(outfile, "graph.dot")
+  expect_equal(readLines(outfile_abnLearned), readLines(outfile_abnFit))
 })


### PR DESCRIPTION
Closes #190 

This originated from the failing deployment test for Windows which uses the newer version of testthat. 
https://github.com/furrer-lab/abn/actions/runs/24714014543/job/72285619505

We are relying on catching some exception based on content from the explanatory message which fails in a newer version (and is also bad practice).