### PR TITLE
Remove irrelevant plot in data_simulation vignette

### DIFF
--- a/vignettes/data_simulation.Rmd
+++ b/vignettes/data_simulation.Rmd
@@ -164,7 +164,5 @@ for (i in seq_along(variables)) {
 do.call(grid.arrange, c(plots, ncol = 1))
 ```
 
-![plot of chunk unnamed-chunk-3](unnamed-chunk-3-1.png)
-
 The plots show that the distributions of the original and simulated data are similar.
 


### PR DESCRIPTION
The plot at line 173 in data_simulation.Rmd does not appear to be related to the example described in the vignette.

This PR removes the plot to avoid confusion.