### PR TITLE
fix: reduce buildScoreCache example size and clean up export_abnFit example

### DIFF
--- a/R/build_score_cache.R
+++ b/R/build_score_cache.R
@@ -280,7 +280,7 @@ build.control <-
 #' @examples
 #' ## Simple example
 #' # Generate data
-#' N <- 1e6
+#' N <- 100
 #' mydists <- list(a="gaussian",
 #'                 b="gaussian",
 #'                 c="gaussian")

--- a/R/export.R
+++ b/R/export.R
@@ -151,14 +151,11 @@
 #'
 #' @examples
 #' \dontrun{
-#' # Load example data and fit a model
-#' library(abn)
-#' data(ex1.dag.data)
-#'
-#' # Define distributions
+#' # Fit a model
 #' mydists <- list(b1 = "binomial", p1 = "poisson", g1 = "gaussian",
 #'                 b2 = "binomial", p2 = "poisson", g2 = "gaussian",
-#'                 b3 = "binomial", g3 = "gaussian")
+#'                 b3 = "binomial", b4 = "binomial", b5 = "binomial",
+#'                 g3 = "gaussian")
 #'
 #' # Build score cache
 #' mycache <- buildScoreCache(data.df = ex1.dag.data,

--- a/man/buildScoreCache.Rd
+++ b/man/buildScoreCache.Rd
@@ -241,7 +241,7 @@ The numerical routines used here are identical to those in \code{\link{fitAbn}} 
 \examples{
 ## Simple example
 # Generate data
-N <- 1e6
+N <- 100
 mydists <- list(a="gaussian",
                 b="gaussian",
                 c="gaussian")

--- a/man/export_abnFit.Rd
+++ b/man/export_abnFit.Rd
@@ -183,14 +183,11 @@ array within each coefficient.
 
 \examples{
 \dontrun{
-# Load example data and fit a model
-library(abn)
-data(ex1.dag.data)
-
-# Define distributions
+# Fit a model
 mydists <- list(b1 = "binomial", p1 = "poisson", g1 = "gaussian",
                 b2 = "binomial", p2 = "poisson", g2 = "gaussian",
-                b3 = "binomial", g3 = "gaussian")
+                b3 = "binomial", b4 = "binomial", b5 = "binomial",
+                g3 = "gaussian")
 
 # Build score cache
 mycache <- buildScoreCache(data.df = ex1.dag.data,


### PR DESCRIPTION
## Summary

This PR addresses issue #254 by making the following documentation improvements:

### Changes

1. **R/build_score_cache.R** (line 283): Reduced N from 1e6 to 100 in the buildScoreCache() example. 1 million observations is excessive for a simple example; 100 is sufficient to demonstrate the workflow.

2. **R/export.R** (lines 152-161): Cleaned up export_abnFit() example:
   - Removed unnecessary `data(ex1.dag.data)` call (data is available via lazy loading)
   - Removed unnecessary `library(abn)` call (not needed in examples)
   - Fixed missing distributions: added `b4 = "binomial"` and `b5 = "binomial"` to match the 10 variables in `ex1.dag.data`

3. **man/buildScoreCache.Rd** and **man/export_abnFit.Rd**: Updated Rd files to match roxygen source

### Validation

- Verified ex1.dag.data has 10 columns: b1, p1, g1, b2, p2, b3, g2, b4, b5, g3
- Verified the fixed mydists list now has 10 matching entries
- Verified the diff is small and focused (4 files, 8 insertions, 14 deletions)

### Related Issues

- Addresses items from #254 (Examples in documentation)
- Builds on previous fix from #240 (export_abnFit example)
