### PR TITLE
use new images

### DIFF
--- a/.github/valgrind-r.supp
+++ b/.github/valgrind-r.supp
@@ -3,6 +3,7 @@
    Memcheck:Leak
    match-leak-kinds: definite
    fun:malloc
+   fun:malloc
    fun:resize_scopes
    ...
    fun:AddDLL

--- a/.github/valgrind-r.supp
+++ b/.github/valgrind-r.supp
@@ -1,0 +1,9 @@
+{
+   r_adddll_loader_scope
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:resize_scopes
+   ...
+   fun:AddDLL
+}

--- a/.github/workflows/onlabel_CRAN_checks.yml
+++ b/.github/workflows/onlabel_CRAN_checks.yml
@@ -70,10 +70,9 @@ jobs:
       fail-fast: false
       matrix:
         container:
-          - 'debian-gcc-devel'
           - 'debian-gcc-release'
-          - 'debian-gcc-patched'
           - 'debian-clang-devel'
+          - 'fedora-gcc-devel'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/onlabel_memory_checks.yml
+++ b/.github/workflows/onlabel_memory_checks.yml
@@ -108,13 +108,14 @@ jobs:
         shell: Rscript {0}
       - name: valgrind - memcheck for ${{ matrix.testfile }}
         run: |
-          R -d "valgrind --tool=memcheck \
-          --leak-check=full \
-          --errors-for-leak-kinds=definite \
-          --track-origins=yes \
-          --error-exitcode=1" \
-          --vanilla \
-          -e "devtools::test_active_file('${{ matrix.testfile }}')"
+           R -d "valgrind --tool=memcheck \
+           --leak-check=full \
+           --suppressions=.github/valgrind-r.supp \
+           --errors-for-leak-kinds=definite \
+           --track-origins=yes \
+           --error-exitcode=1" \
+           --vanilla \
+           -e "devtools::test_active_file('${{ matrix.testfile }}')"
         shell: bash
 
   report_memory_checks:

--- a/.github/workflows/onlabel_memory_checks.yml
+++ b/.github/workflows/onlabel_memory_checks.yml
@@ -82,7 +82,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Installing valgrind
-        if: ${{ !startsWith(matrix.container, 'valgrind') }}
+        if: ${{ !startsWith(matrix.container, 'fedora-valgrind') }}
         run: |
           apt-get update && apt-get install valgrind -y
         shell: bash

--- a/.github/workflows/onlabel_memory_checks.yml
+++ b/.github/workflows/onlabel_memory_checks.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         testfile: ${{ fromJson(needs.gather_tests.outputs.testfiles) }}
         container:
-          - 'valgrind-gcc-devel'
+          - 'fedora-valgrind-gcc-devel'
           - 'debian-gcc-release'
     container:
       image: ${{ vars.CONTAINER_SOURCE || 'ghcr.io/furrer-lab/r-containers' }}/${{ matrix.container }}/abn:${{ vars.CONTAINER_VERSION || 'latest' }}


### PR DESCRIPTION
Recently the `r-container` updated the source of their base images and changed the selection of container images they offer: https://github.com/furrer-lab/r-containers/pull/69

We need to make sure to use containers for our checks that are regularly updated and maintained upstream, i.e. r-container and then r-hub.