### PR TITLE
Fix for JAGS 5.0.0

### DIFF
--- a/tests/testthat/test-simulateabn.R
+++ b/tests/testthat/test-simulateabn.R
@@ -741,7 +741,7 @@ test_that("simulateAbn() simulation works with method 'mle'", {
                                n.chains = 10L,
                                n.adapt = 1000L,
                                n.thin = 100L,
-                               n.iter = 10000L,
+                               n.iter = 50000L,
                                seed = 42L,
                                verbose = FALSE)
     })


### PR DESCRIPTION
As suggested by @martynplummer,  we update n.iter from 10000L to 50000L in in the test functions for the release of JAGS 5.0.0.